### PR TITLE
fix: make return value None when velue is none and not use pydantic m…

### DIFF
--- a/src/openapi_python_generator/language_converters/python/templates/aiohttp.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/aiohttp.jinja2
@@ -74,7 +74,7 @@ try:
 {% elif return_type.complex_type and async_client %}
     {%- if return_type.list_type is none %}
             response = await inital_response.json()
-            return {{ return_type.type.converted_type }}(**response) if response is not None else {{ return_type.type.converted_type }}()
+            return {{ return_type.type.converted_type }}(**response) if response is not None else None()
     {%- else %}
             response = await inital_response.json()
             return [{{ return_type.list_type }}(**item) for item in response]
@@ -83,7 +83,7 @@ try:
 {% elif return_type.complex_type and not async_client%}
     {%- if return_type.list_type is none %}
             response = inital_response.json()
-            return {{ return_type.type.converted_type }}(**response) if response is not None else {{ return_type.type.converted_type }}()
+            return {{ return_type.type.converted_type }}(**response) if response is not None else None()
     {%- else %}
             response = await inital_response.json()
             return [{{ return_type.list_type }}(**item) for item in response]


### PR DESCRIPTION
When the returned value from the service is none, do not return an empty pydantic model since that will violate the model.